### PR TITLE
Use the right location for the types

### DIFF
--- a/src/app/__snapshots__/index.test.js.snap
+++ b/src/app/__snapshots__/index.test.js.snap
@@ -132,7 +132,6 @@ Object {
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "test": "jest",
   },
-  "types": "types/index.d.ts",
   "version": "0.0.0-development",
 }
 `;
@@ -224,7 +223,7 @@ Object {
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "test": "jest",
   },
-  "types": "types/index.d.ts",
+  "types": "dist/index.d.ts",
   "version": "0.0.0-development",
 }
 `;

--- a/src/app/defaults.js
+++ b/src/app/defaults.js
@@ -1,7 +1,6 @@
 export const defaultPackageJson = {
   version: '0.0.0-development',
   main: 'dist/index.js',
-  types: 'types/index.d.ts',
   scripts: {
     precommit: 'lint-staged',
     commit: 'git-cz',

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -158,6 +158,7 @@ export default class extends Generator {
         },
         defaultPackageJson.devDependencies
       )
+      platformProperties["types"] ='dist/index.d.ts',
 
       platformProperties['lint-staged'] = {
         '*.@(ts|tsx)': ['tslint --fix', 'npm run prettier-write --', 'git add'],

--- a/src/app/templates/ts/src/index.test.ts
+++ b/src/app/templates/ts/src/index.test.ts
@@ -17,7 +17,7 @@ describe("<%= pluginFunctionName %>()", () => {
     global.markdown = undefined
   })
 
-  it("Checks for a that message has been called", () => {
+  it("Checks that message has been called", () => {
     global.danger = {
       github: { pr: { title: "My Test Title" } },
     }

--- a/src/app/templates/ts/src/index.ts
+++ b/src/app/templates/ts/src/index.ts
@@ -1,10 +1,13 @@
-// Provides dev-time type structures for  `danger` - doesn't affect runtime.
+// Provides dev-time type structures for `danger` - doesn't affect runtime,
+// and are not exported out.
+//
 import {DangerDSLType} from "../node_modules/danger/distribution/dsl/DangerDSL"
+
 declare var danger: DangerDSLType
-export declare function message(message: string): void
-export declare function warn(message: string): void
-export declare function fail(message: string): void
-export declare function markdown(message: string): void
+declare function message(message: string): void
+declare function warn(message: string): void
+declare function fail(message: string): void
+declare function markdown(message: string): void
 
 /**
  * <%= description %>


### PR DESCRIPTION
Now the definitions work inside TS. And there's no chance of an accidental import of  `{message}` from a plugin.